### PR TITLE
Fixed: Upgrading stale packages before git installation (git might be even missing if packages are too old)

### DIFF
--- a/shell/main.sh
+++ b/shell/main.sh
@@ -10,8 +10,10 @@ APT_GET=/usr/bin/apt-get
 YUM=/usr/sbin/yum
 if [ ! -x $GIT ]; then
     if [ -x $YUM ]; then
+        yum -q -y makecache
         yum -q -y install git
     elif [ -x $APT_GET ]; then
+        apt-get -q -y update
         apt-get -q -y install git
     else
         echo "No package installer available. You may need to install git manually."


### PR DESCRIPTION
Fixed: Upgrading stale packages before git installation (git might be even missing if packages are too old).
I didn't verified this code on CentOS as I don't have any CentOS-based box running. But without this line for Debian I was unable to install GIT on Debian using the following box: `http://andrew.mcnaughty.com/downloads/squeeze64_puppet27.box`
