### PR TITLE
Always install 'librarian-puppet' as a gem in apt-based systems

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,11 @@ Vagrant.configure("2") do |config|
   # This shell provisioner installs librarian-puppet and runs it to install
   # puppet modules. This has to be done before the puppet provisioning so that
   # the modules are available when puppet tries to parse its manifests.
-  config.vm.provision :shell, :path => "shell/librarian-puppet.sh"
+  config.vm.provision :shell do |shell|
+    shell.path = "shell/librarian-puppet.sh"
+  # uncomment the next line if you want to install the librarian-ruby gem instead the package
+  #  shell.args = "-g"
+  end
 
   # Now run the puppet provisioner. Note that the modules directory is entirely
   # managed by librarian-puppet

--- a/shell/librarian-puppet.sh
+++ b/shell/librarian-puppet.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Check the received options in order to set up some variables
+PREFER_PACKAGE=1
+while getopts ":g" opt; do
+  case $opt in
+    g)
+      echo "Using the gem installer"
+      PREFER_PACKAGE=0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
 PATH=$PATH:/usr/local/bin/
 
 # Directory in which librarian-puppet should manage its modules directory
@@ -57,15 +71,22 @@ elif [ "${FOUND_APT}" -eq '0' ]; then
 
   # Make sure librarian-puppet is installed
   if [ "$FOUND_LP" -ne '0' ]; then
-    dpkg -s ruby-json >/dev/null 2>&1
-    if [ $? -ne 0 -a -n "$(apt-cache search ruby-json)" ]; then
-      # Try and install json dependency from package if possible
-      apt-get -q -y install ruby-json
+    if [ "$PREFER_PACKAGE" -eq 1 -a -n "$(apt-cache search librarian-puppet)" ]; then
+       apt-get -q -y install librarian-puppet
+       echo 'Librarian-puppet installed from package'
     else
-      echo 'The ruby_json package is not installed. Attempting to install librarian-puppet anyway.'
+      dpkg -s ruby-json >/dev/null 2>&1
+      if [ $? -ne 0 -a -n "$(apt-cache search ruby-json)" ]; then
+        # Try and install json dependency from package if possible
+        apt-get -q -y install ruby-json
+      else
+        echo 'The ruby_json package was not installed (maybe, it was present). Attempting to install librarian-puppet anyway.'
+      fi
+      if [ -n "$(apt-cache search ruby1.9.1-dev)" ]; then
+        apt-get -q -y install ruby1.9.1-dev
+      fi
+      InstallLibrarianPuppetGem
     fi
-    apt-get -q -y install ruby1.9.1-dev
-    InstallLibrarianPuppetGem
   fi
 
 else

--- a/shell/librarian-puppet.sh
+++ b/shell/librarian-puppet.sh
@@ -57,17 +57,12 @@ elif [ "${FOUND_APT}" -eq '0' ]; then
 
   # Make sure librarian-puppet is installed
   if [ "$FOUND_LP" -ne '0' ]; then
-
-    if [ -n "$(apt-cache search librarian-puppet)" ]; then
-       apt-get -q -y install librarian-puppet
-       echo 'Librarian-puppet installed from package'
-    else
-       if [ -n "$(apt-cache search ruby-json)" ]; then
-         # Try and install json dependency from package if possible
-         apt-get -q -y install ruby-json
-       fi
-       InstallLibrarianPuppetGem
+    if [ -n "$(apt-cache search ruby-json)" ]; then
+      # Try and install json dependency from package if possible
+      apt-get -q -y install ruby-json
     fi
+    apt-get -q -y install ruby1.9.1-dev
+    InstallLibrarianPuppetGem
   fi
 
 else

--- a/shell/librarian-puppet.sh
+++ b/shell/librarian-puppet.sh
@@ -62,9 +62,12 @@ elif [ "${FOUND_APT}" -eq '0' ]; then
        apt-get -q -y install librarian-puppet
        echo 'Librarian-puppet installed from package'
     else
-       if [ -n "$(apt-cache search ruby-json)" ]; then
+       dpkg -s ruby-json >/dev/null 2>&1
+       if [ $? -ne 0 -a -n "$(apt-cache search ruby-json)" ]; then
          # Try and install json dependency from package if possible
          apt-get -q -y install ruby-json
+       else
+         echo 'The ruby_json package is not installed. Attempting to install librarian-puppet anyway.'
        fi
        InstallLibrarianPuppetGem
     fi


### PR DESCRIPTION
The librarian-puppet packages for `apt` install old versions of the lib (check https://packages.qa.debian.org/libr/librarian-puppet.html and http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=librarian-puppet&searchon=names for more details), let's go with `gem`!

Also, this PR adds the ruby1.9.1-dev packages (required by `gem` installer) and checks if the ruby-json package is not installed in order to avoid unrequired system changes.
